### PR TITLE
Combine short flags

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -361,6 +361,11 @@ fi
 //
 // args: set nil to use os.Args[1:] by default
 func (p *Parser) Parse(args []string) error {
+	p.Invoked = false
+	for _, s := range p.subParser {
+		s.Invoked = false
+	}
+
 	if args == nil {
 		args = os.Args[1:]
 	}
@@ -370,6 +375,8 @@ func (p *Parser) Parse(args []string) error {
 	}
 	var subParser *Parser
 	if len(args) == 0 {
+		p.Invoked = true // when there is any match, it's invoked, or the default action will be called
+
 		if p.config.DefaultAction != nil {
 			p.config.DefaultAction()
 		} else if !p.config.DisableDefaultShowHelp {
@@ -377,7 +384,6 @@ func (p *Parser) Parse(args []string) error {
 			p.showHelp = &help
 		}
 	} else {
-		p.Invoked = true // when there is any match, it's invoked, or the default action will be called
 		if matchSub {
 			subParser = p.subParserMap[args[0]]
 			e := subParser.Parse(args[1:])
@@ -385,6 +391,7 @@ func (p *Parser) Parse(args []string) error {
 				return e
 			}
 		} else {
+			p.Invoked = true // when there is any match, it's invoked, or the default action will be called
 			lastPositionArgIndex := 0
 			registeredPositionsLength := len(p.positionArgs)
 			for len(args) > 0 {

--- a/parse_test.go
+++ b/parse_test.go
@@ -717,3 +717,46 @@ func TestParser_InvokeDisableDefaultHelp(t *testing.T) {
 		t.Error("sub invoked false")
 	}
 }
+
+func TestParser_CombinedShort(t *testing.T) {
+	p := NewParser("combine short", "tests combined short flags", nil)
+
+	f1 := p.Flag("a", "", nil)
+	f2 := p.Flag("b", "", nil)
+
+	sub := p.AddCommand("sub", "combined short on sub", nil)
+	sf1 := sub.Flag("a", "", nil)
+	sf2 := sub.Flag("b", "", nil)
+
+	f1_set := false
+	f2_set := false
+
+	p.InvokeAction = func() {
+		f1_set = *f1
+		f2_set = *f2
+	}
+
+	sub.InvokeAction = func() {
+		f1_set = *sf1
+		f2_set = *sf2
+	}
+
+	for _, base := range [][]string{{}, {"sub"}} {
+		if err := p.Parse(append(base, "-ab")); err != nil {
+			t.Error(err)
+		} else {
+			if !*f1 {
+				t.Error("f1 not set")
+			}
+			if !*f2 {
+				t.Error("f2 not set")
+			}
+			if !f1_set {
+				t.Error("f1 not set")
+			}
+			if !f2_set {
+				t.Error("f2 not set")
+			}
+		}
+	}
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -621,47 +621,99 @@ func TestParse_AllowShort(t *testing.T) {
 	}
 }
 
-func TestParser_Invoke(t *testing.T) {
-	p := NewParser("", "", nil)
-	a := p.String("a", "", nil)
-	sub := p.AddCommand("sub", "", nil)
-	b := sub.String("b", "", nil)
-	mainParsed := false
-	subParsed := false
-	No2Parsed := false
-	p.InvokeAction = func() {
-		mainParsed = true
-		if *a != "" {
-			t.Error("error!")
-		}
-	}
-	sub.InvokeAction = func() {
-		subParsed = true
-		if *b != "linux" {
-			t.Error("failed to bind")
-			return
-		}
-	}
-	subNo2 := p.AddCommand("sub2", "", nil)
-	subNo2.Int("a", "", nil)
-	subNo2.InvokeAction = func() {
-		No2Parsed = true
+func TestParser_InvokeDisableDefaultHelp(t *testing.T) {
+	o := &ParserConfig{
+		DisableDefaultShowHelp: true,
 	}
 
-	if e := p.Parse([]string{"sub", "-b", "linux"}); e != nil {
-		t.Error(e.Error())
-		return
+	mainInvoked := false
+	subInvoked := false
+
+	p := NewParser("test", "test desc", o)
+	p.Flag("t", "test", nil)
+
+	sub := p.AddCommand("sub", "sub cmd", nil)
+	sub.Flag("t", "test", nil)
+
+	for _, info := range []struct {
+		args        []string
+		mainInvoked bool
+	}{
+		{[]string{}, true},
+		{[]string{"-t"}, true},
+		{[]string{"sub"}, false},
+		{[]string{"sub", "-t"}, false},
+	} {
+		for _, doInvokeFunc := range []bool{true, false} {
+			mainInvoked = false
+			subInvoked = false
+
+			if doInvokeFunc {
+				p.InvokeAction = func() { mainInvoked = true }
+				sub.InvokeAction = func() { subInvoked = true }
+			} else {
+				p.InvokeAction = func() {}
+				sub.InvokeAction = func() {}
+			}
+
+			if err := p.Parse(info.args); err != nil {
+				t.Error(err)
+			} else {
+				pi := p.Invoked
+				si := sub.Invoked
+
+				if info.mainInvoked {
+					if !pi {
+						t.Error("main not invoked")
+					}
+					if mainInvoked != doInvokeFunc {
+						t.Error("main invoke func bool not changed")
+					}
+
+					if si {
+						t.Error("sub invoked")
+					}
+					if subInvoked {
+						t.Error("sub invoked ran")
+					}
+				} else {
+					if pi {
+						t.Error("main invoked")
+					}
+					if mainInvoked {
+						t.Error("main invoked ran")
+					}
+
+					if !si {
+						t.Error("sub not invoked")
+					}
+					if subInvoked != doInvokeFunc {
+						t.Error("sub invoke func bool not changed")
+					}
+				}
+			}
+		}
 	}
-	if !p.Invoked || !mainParsed {
-		t.Error("main parse state error")
-		return
+
+	if err := p.Parse([]string{}); err != nil {
+		t.Error(err)
 	}
-	if !sub.Invoked || !subParsed {
-		t.Error("sub parse state error")
-		return
+
+	if !p.Invoked {
+		t.Error("main invoked false")
 	}
-	if subNo2.Invoked || No2Parsed {
-		t.Error("irrelevant parse state error")
-		return
+	if sub.Invoked {
+		t.Error("sub invoked true")
+	}
+
+	if err := p.Parse([]string{"sub"}); err != nil {
+		t.Error(err)
+	}
+
+	if p.Invoked {
+		t.Error("main invoked true")
+	}
+	if !sub.Invoked {
+		t.Error("sub invoked false")
 	}
 }


### PR DESCRIPTION
Any short flag that is a single rune is added to a list of okay flags to
combine, so you can do `-ab` as shorthand for `-a` `-b`.  Short flags
that are longer, or any argument that takes another arg (ie int, string)
are currently not allowed to be combined.

I based this off of the `fixInvoked` branch otherwise the tests wouldn't
pass.