### PR TITLE
Properly decide terminal width on non-unix systems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/hellflame/argparse
 
 go 1.16
+
+require golang.org/x/term v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/utils.go
+++ b/utils.go
@@ -3,23 +3,15 @@ package argparse
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"strconv"
 	"strings"
+
+	"golang.org/x/term"
 )
 
 func decideTerminalWidth() int {
-	// decide terminal width
-	cmd := exec.Command("stty", "size")
-	cmd.Stdin = os.Stdin // this is important
-	result, e := cmd.Output()
-	if e != nil {
-		result = []byte("0 80")
-	}
-	width := 80
-	parse := strings.Split(strings.TrimRight(string(result), "\n"), " ")
-	if w, e := strconv.Atoi(parse[1]); e == nil {
-		width = w
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return 80
 	}
 	return width
 }


### PR DESCRIPTION
# Pull Request Process

## Before submitting a pull request

Be sure you have the latest code in hand. Pull the `master` branch

Be sure to `make test` and keep all test pass

Be sure to `make tidy` so your code style will keep the same

Be sure to `make cover-report` to see if any line not covered

__Don't Rebase git history__

## General steps for completing this pull request

### Checklist

> Does your project contributions have steps to follow before being approved? Tests, documentation changing, etc?

Ensure that your `pull request` has followed all the steps below:

- [x] Code compilation
- [x] All tests passing
- [x] Extended the documentation, if applicable

### Description

> Ask the contributor to describe his `pull request`.

stty isn't available on Windows. This patch uses golang.org/x/term instead to determine the actual terminal width. This makes it work on Windows without issues.

## Proposed changes

> Ask contributors about why you (or your project maintainers) would accept the pull request. If it solves a previous request, also ask to link to that issue.

This improves the UX on Windows, or any other system where the "stty" command may not be available.

### Types of changes

> Show in a checkbox-style, the expected types of changes your project is supposed to have:

- [ ] New feature
- [x] Bugfix
- [x] Improve
- [ ] So on...

